### PR TITLE
Split, rsplit and join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,11 @@ Result/
 Automata Library/
 Test Results/
 Custom Bases/
+Word Automata Library/test**.txt
 
 # Directory for experiments
 scratch/
+
 
 # Intellij Idea Files
 .idea

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -1369,8 +1369,15 @@ public class Automaton {
         return first;
     }
 
+    /**
+     * @param outputs A list of integers, indicating which uncombined automata and in what order to return.
+     * @return A list of automata, each corresponding to the list of outputs.
+     * For the sake of an example, suppose that outputs is [0,1,2], then we return the list of automaton without output
+     * which accepts if the output in our automaton is 0,1 or 2 respectively.
+     * @throws Exception
+     */
     public List<Automaton> uncombine(List<Integer> outputs, boolean print, String prefix, StringBuffer log) throws Exception {
-        List<Automaton> automata = new ArrayList<Automaton>();
+        List<Automaton> automata = new ArrayList<>();
         for (Integer output : outputs) {
             Automaton M = clone();
             for (int j = 0; j < M.O.size(); j++) {
@@ -1385,6 +1392,13 @@ public class Automaton {
         return automata;
     }
 
+
+    /**
+     * @return A minimized DFA with output recognizing the same language as the current DFA (possibly also with output).
+     * We minimize a DFA with output by first uncombining into automata without output, minimizing the uncombined automata, and
+     * then recombining. It follows that if the ubcombined autoamta are minimal, then the combined automata is also minimal
+     * @throws Exception
+     */
     public Automaton minimizeWithOuput(boolean print, String prefix, StringBuffer log) throws Exception {
         List<Integer> outputs = new ArrayList<>(O);
         UtilityMethods.removeDuplicates(outputs);
@@ -1440,6 +1454,16 @@ public class Automaton {
         return "";
     }
 
+    /**
+     * @param inputs A list of "+", "-" or "". Indicating how our input will be interpreted in the output automata.
+     *               Inputs must correspond to inputs of the current automaton
+     *               which can be compared to some corresponding negative base.
+     * @return The automaton which replaces inputs in negative base with an input in corresponding comparable positive base.
+     * For sake of example, suppose the input is [+,-,] and M is the current automata with inputs in base -2.
+     * On inputs (x,y,z), where x,y are inputs in base 2, the automaton gives as output M(x',y',z) where
+     * x' and y' are in the corresponding base -2 representations of x and -y.
+     * @throws Exception
+     */
     public Automaton split(List<String> inputs, boolean print, String prefix, StringBuffer log) throws Exception {
         if(alphabetSize == 0) {
             throw new Exception("Cannot split automaton with no inputs.");
@@ -1494,6 +1518,17 @@ public class Automaton {
         return M;
     }
 
+    /**
+     * @param inputs A list of "+", "-" or "". Indicating how our input will be interpreted in the output automata.
+     *               Inputs must correspond to inputs of the current automaton
+     *               which can be compared to some corresponding negative base.
+     * @return The automaton which replaces inputs in positive base with an input in corresponding comparable negative base.
+     * For sake of example, suppose the input is [+,-,] and M is the current automata with inputs in base 2.
+     * On inputs (x,y,z), where x,y are inputs in base -2, the automaton gives as output M(x',y',z) where
+     * x' and y' are in the corresponding base 2 representations of x and -y. If x or -y has no corresponding
+     * base 2 representation, then the automaton outputs 0.
+     * @throws Exception
+     */
     public Automaton reverseSplit(List<String> inputs, boolean print, String prefix, StringBuffer log) throws Exception {
         if(alphabetSize == 0) {
             throw new Exception("Cannot reverse split automaton with no inputs.");
@@ -1548,6 +1583,14 @@ public class Automaton {
         return M;
     }
 
+
+    /**
+     * @param subautomata A queue of automaton which we will "join" with the current automaton.
+     * @return The cross product of the current automaton and automaton in subautomata, using the operation "first" on the outputs.
+     * For sake of example, the current Automaton is M1, and subautomata consists of M2 and M3.
+     * Then on input x, returned automaton should output the first value of [ M1(x), M2(x), M3(x) ] which is non-zero.
+     * @throws Exception
+     */
     public Automaton join(Queue<Automaton> subautomata, boolean print, String prefix, StringBuffer log) throws Exception {
         Automaton first = this.clone();
 

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -1403,6 +1403,46 @@ public class Automaton {
         return "";
     }
 
+    public List<Automaton> split(boolean print, String prefix, StringBuffer log) throws Exception {
+        List<Automaton> splitAutomata = new ArrayList<Automaton>();
+        if(alphabetSize == 0) {
+            throw new Exception("Cannot split automaton with no inputs.");
+        }
+        int compareIndex = -1;
+        for(int i = 0; i < NS.size(); i++) {
+            if (NS.get(i).comparison_neg != null) {
+                compareIndex = i;
+                break;
+            }
+        }
+        if(compareIndex == -1) {
+            throw new Exception("Cannot split automaton which has no negative base inputs.");
+        }
+        randomLabel();
+        String a = label.get(compareIndex);
+        String b = a+a, c = a+b;
+        Automaton compare = NS.get(compareIndex).comparison_neg.clone();
+
+        compare.bind(b, a);
+        Automaton M = and(compare, print, prefix, log);
+        M.quantify(a, print, prefix, log);
+        M.unlabel();
+        splitAutomata.add(M);
+
+        compare.bind(b, c);
+        Automaton N = and(compare, print, prefix, log);
+        N = N.and(NS.get(compareIndex).arithmetic(a,c,0,"+"), print, prefix, log);
+        N.quantify(a, c, false, print, prefix, log);
+        N.unlabel();
+        splitAutomata.add(N);
+
+        return splitAutomata;
+    }
+
+    public void join(Automaton N, boolean print, String prefix, StringBuffer log) throws Exception {
+        // TODO
+    }
+
     // helper function for inf, finds an input string that leads from q0 to the specified state
     private String constructPrefix(Integer target) {
         List<Integer> distance = new ArrayList<Integer>(Collections.nCopies(Q, -1));
@@ -1847,6 +1887,10 @@ public class Automaton {
         } catch (UnsupportedEncodingException e2) {
             e2.printStackTrace();
         }
+    }
+
+    public void debug_draw(String filename) throws Exception {
+        draw(UtilityMethods.get_address_for_result()+filename+".gv","???", false);
     }
 
     /**

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -1366,7 +1366,7 @@ public class Automaton {
             // crossProduct requires both automata to be totalized, otherwise it has no idea which cartesian states to transition to
             first.totalize(print,prefix+" ",log);
             next.totalize(print,prefix+" ",log);
-            Automaton product = first.crossProduct(next, "combine", print, prefix, log);
+            Automaton product = first.crossProduct(next, "combine", print, prefix+" ", log);
             product.combineIndex = first.combineIndex + 1;
             product.combineOutputs = first.combineOutputs;
             first = product;
@@ -1618,8 +1618,8 @@ public class Automaton {
             // crossProduct requires both automata to be totalized, otherwise it has no idea which cartesian states to transition to
             first.totalize(print,prefix+" ",log);
             next.totalize(print,prefix+" ",log);
-            first = first.crossProduct(next, "first", print, prefix, log);
-            first = first.minimizeWithOuput(print,prefix,log);
+            first = first.crossProduct(next, "first", print, prefix+" ", log);
+            first = first.minimizeWithOuput(print,prefix+" ",log);
 
             long timeAfter = System.currentTimeMillis();
             if(print){

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -1352,7 +1352,12 @@ public class Automaton {
         first.combineOutputs = outputs;
         while (subautomata.size() > 0) {
             Automaton next = subautomata.remove();
-            // potentially add logging later
+            long timeBefore = System.currentTimeMillis();
+            if(print){
+                String msg = prefix + "computing =>:" + first.Q + " states - " + next.Q + " states";
+                log.append(msg + UtilityMethods.newLine());
+                System.out.println(msg);
+            }
 
             // crossProduct requires labelling so we make an arbitrary labelling and use it for both: this is valid since
             // input alphabets and arities are assumed to be identical for the combine method
@@ -1365,6 +1370,13 @@ public class Automaton {
             product.combineIndex = first.combineIndex + 1;
             product.combineOutputs = first.combineOutputs;
             first = product;
+
+            long timeAfter = System.currentTimeMillis();
+            if(print){
+                String msg = prefix + "computed =>:" + first.Q + " states - "+(timeAfter-timeBefore)+"ms";
+                log.append(msg + UtilityMethods.newLine());
+                System.out.println(msg);
+            }
         }
         return first;
     }
@@ -1588,7 +1600,7 @@ public class Automaton {
      * @param subautomata A queue of automaton which we will "join" with the current automaton.
      * @return The cross product of the current automaton and automaton in subautomata, using the operation "first" on the outputs.
      * For sake of example, the current Automaton is M1, and subautomata consists of M2 and M3.
-     * Then on input x, returned automaton should output the first value of [ M1(x), M2(x), M3(x) ] which is non-zero.
+     * Then on input x, returned automaton should output the first non-zero value of [ M1(x), M2(x), M3(x) ].
      * @throws Exception
      */
     public Automaton join(Queue<Automaton> subautomata, boolean print, String prefix, StringBuffer log) throws Exception {
@@ -1596,13 +1608,25 @@ public class Automaton {
 
         while (subautomata.size() > 0) {
             Automaton next = subautomata.remove();
-            // potentially add logging later
+            long timeBefore = System.currentTimeMillis();
+            if(print){
+                String msg = prefix + "computing =>:" + first.Q + " states - " + next.Q + " states";
+                log.append(msg + UtilityMethods.newLine());
+                System.out.println(msg);
+            }
 
             // crossProduct requires both automata to be totalized, otherwise it has no idea which cartesian states to transition to
             first.totalize(print,prefix+" ",log);
             next.totalize(print,prefix+" ",log);
             first = first.crossProduct(next, "first", print, prefix, log);
             first = first.minimizeWithOuput(print,prefix,log);
+
+            long timeAfter = System.currentTimeMillis();
+            if(print){
+                String msg = prefix + "computed =>:" + first.Q + " states - "+(timeAfter-timeBefore)+"ms";
+                log.append(msg + UtilityMethods.newLine());
+                System.out.println(msg);
+            }
         }
         return first;
     }

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -1331,22 +1331,25 @@ public class Automaton {
 			Automaton M = new Automaton(UtilityMethods.get_address_for_automata_library()+name+".txt");
 			subautomata.add(M);
 		}
+        return combine(subautomata, outputs, print, prefix, log);
+    }
 
-		Automaton first = this.clone();
-	
-		// In an automaton without output, every non-zero output value represents an accepting state
+    public Automaton combine(Queue<Automaton> subautomata, List<Integer> outputs, boolean print, String prefix, StringBuffer log) throws Exception {
+        Automaton first = this.clone();
+
+        // In an automaton without output, every non-zero output value represents an accepting state
         // we change this to correspond to the value assigned to the first automaton by our command
-		for (int q = 0; q < first.Q; q++) {
-			if (first.O.get(q) != 0) {
-				first.O.set(q, outputs.get(0));
-			}
-		}
-		first.combineIndex = 1;
+        for (int q = 0; q < first.Q; q++) {
+            if (first.O.get(q) != 0) {
+                first.O.set(q, outputs.get(0));
+            }
+        }
+        first.combineIndex = 1;
         first.combineOutputs = outputs;
-		while (subautomata.size() > 0) {
-			Automaton next = subautomata.remove();
-			// potentially add logging later
-            
+        while (subautomata.size() > 0) {
+            Automaton next = subautomata.remove();
+            // potentially add logging later
+
             // crossProduct requires labelling so we make an arbitrary labelling and use it for both: this is valid since
             // input alphabets and arities are assumed to be identical for the combine method
             first.randomLabel();
@@ -1354,12 +1357,28 @@ public class Automaton {
             // crossProduct requires both automata to be totalized, otherwise it has no idea which cartesian states to transition to
             first.totalize(print,prefix+" ",log);
             next.totalize(print,prefix+" ",log);
-			Automaton product = first.crossProduct(next, "combine", print, prefix, log);
-			product.combineIndex = first.combineIndex + 1;
+            Automaton product = first.crossProduct(next, "combine", print, prefix, log);
+            product.combineIndex = first.combineIndex + 1;
             product.combineOutputs = first.combineOutputs;
-			first = product;
-		}
+            first = product;
+        }
         return first;
+    }
+
+    public List<Automaton> uncombine(List<Integer> outputs, boolean print, String prefix, StringBuffer log) throws Exception {
+        List<Automaton> automata = new ArrayList<Automaton>();
+        for(int i = 0; i < outputs.size(); i++) {
+            Automaton M = clone();
+            for(int j = 0; j < M.O.size(); j++) {
+                if (M.O.get(j).equals(outputs.get(i))) {
+                    M.O.set(j,1);
+                } else {
+                    M.O.set(j,0);
+                }
+            }
+            automata.add(M);
+        }
+        return automata;
     }
 
     // Determines whether an automaton accepts infinitely many values. If it does, a regex of infinitely many accepted values (not all)
@@ -1457,12 +1476,12 @@ public class Automaton {
         return M;
     }
 
-    public Automaton join(List<String> inputs, boolean print, String prefix, StringBuffer log) throws Exception {
+    public Automaton reverseSplit(List<String> inputs, boolean print, String prefix, StringBuffer log) throws Exception {
         if(alphabetSize == 0) {
-            throw new Exception("Cannot join automaton with no inputs.");
+            throw new Exception("Cannot reverse split automaton with no inputs.");
         }
         if(inputs.size() != A.size()) {
-            throw new Exception("Join automaton has incorrect number of inputs.");
+            throw new Exception("Split automaton has incorrect number of inputs.");
         }
 
         Automaton M = clone();

--- a/src/Automata/Automaton.java
+++ b/src/Automata/Automaton.java
@@ -2077,10 +2077,6 @@ public class Automaton {
         }
     }
 
-    public void debug_draw(String filename) throws Exception {
-        draw(UtilityMethods.get_address_for_result()+filename+".gv","???", false);
-    }
-
     /**
      * Writes down matrices for this automaton to a .mpl file given by the address.
      * @param address

--- a/src/Automata/NumberSystem.java
+++ b/src/Automata/NumberSystem.java
@@ -19,6 +19,7 @@
 package Automata;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -130,7 +131,7 @@ public class NumberSystem {
 		String base = name.substring(name.indexOf("_") + 1);
 
 		/**
-		 * When the number system does not exits, we try to see whether its complement exists or not.
+		 * When the number system does not exist, we try to see whether its complement exists or not.
 		 * For example lsd_2 is the complement of msd_2.
 		 */
 		String complementName = (is_msd ? "lsd":"msd")+"_" + base;
@@ -512,17 +513,20 @@ public class NumberSystem {
 	 * @param n
 	 * @throws Exception
 	 */
-	private Automaton base_n_neg_compare(int n) throws Exception{
+	private Automaton base_n_neg_compare(int n) throws Exception {
 		List<Integer> alphabet = new ArrayList<Integer>();
-		for(int i = 0 ; i < n;i++)alphabet.add(i);
+		for (int i = 0; i < n; i++) alphabet.add(i);
 		Automaton compare = new Automaton();
 		compare.Q = 4;
 		compare.q0 = 0;
-		compare.O.add(1);compare.O.add(1);compare.O.add(0);compare.O.add(0);
-		compare.d.add(new TreeMap<Integer,List<Integer>>());
-		compare.d.add(new TreeMap<Integer,List<Integer>>());
-		compare.d.add(new TreeMap<Integer,List<Integer>>());
-		compare.d.add(new TreeMap<Integer,List<Integer>>());
+		compare.O.add(1);
+		compare.O.add(1);
+		compare.O.add(0);
+		compare.O.add(0);
+		compare.d.add(new TreeMap<Integer, List<Integer>>());
+		compare.d.add(new TreeMap<Integer, List<Integer>>());
+		compare.d.add(new TreeMap<Integer, List<Integer>>());
+		compare.d.add(new TreeMap<Integer, List<Integer>>());
 		if(is_msd) {
 			compare.NS.add(new NumberSystem("msd_"+n));
 			compare.NS.add(this);
@@ -574,6 +578,15 @@ public class NumberSystem {
 			compare.reverse(false,null,null);
 		}
 		return compare;
+	}
+
+	/**
+	 * Gives the corresponding negative number system if one is defined. Throws an exception otherwise.
+	 */
+	public NumberSystem negative_number_system() throws Exception {
+		String msd_or_lsd = name.substring(0, name.indexOf("_"));
+		String base = name.substring(name.indexOf("_") + 1);
+		return new NumberSystem(msd_or_lsd + "_neg_" + base);
 	}
 
 	/**

--- a/src/Automata/NumberSystem.java
+++ b/src/Automata/NumberSystem.java
@@ -19,7 +19,6 @@
 package Automata;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -666,6 +665,7 @@ public class NumberSystem {
 	 * @throws Exception
 	 */
 	public Automaton comparison(String a,int b,String comparisonOperator) throws Exception {
+		if(!is_neg && b < 0)throw new Exception("negative constant " + b);
 		String B = "new " + a;//this way, we make sure B != a.
 		Automaton N,M;
 		if (b < 0) {
@@ -691,6 +691,7 @@ public class NumberSystem {
 	 * @throws Exception
 	 */
 	public Automaton comparison(int a,String b,String comparisonOperator) throws Exception {
+		if(!is_neg && a < 0)throw new Exception("negative constant " + a);
 		switch (comparisonOperator) {
 			case "<":
 				return comparison(b, a, ">");
@@ -755,6 +756,7 @@ public class NumberSystem {
 			int b,
 			String c,
 			String arithmeticOperator) throws Exception {
+		if(!is_neg && b < 0)throw new Exception("negative constant " + b);
 		Automaton N;
 		if(arithmeticOperator.equals("*")){
 			//note that the case of b = 0 is handled in Computer class
@@ -803,6 +805,7 @@ public class NumberSystem {
 		String b,
 		String c,
 		String arithmeticOperator) throws Exception {
+		if(!is_neg && a < 0)throw new Exception("negative constant " + a);
 		Automaton N;
 		if(arithmeticOperator.equals("*")){
 			N = getMultiplication(a);
@@ -851,6 +854,7 @@ public class NumberSystem {
 			String b,
 			int c,
 			String arithmeticOperator) throws Exception {
+		if(!is_neg && c < 0)throw new Exception("negative constant " + c);
 		Automaton N;
 		if(arithmeticOperator.equals("*")) {
 			throw new Exception("the operator * cannot be applied to two variables");
@@ -885,6 +889,9 @@ public class NumberSystem {
 	 * @throws Exception
 	 */
 	private Automaton constant(int n) throws Exception {
+		if (!is_neg && n < 0) {
+			throw new Exception("Constant cannot be negative.");
+		}
 		if (constantsDynamicTable.containsKey(n)) {
 			return constantsDynamicTable.get(n);
 		}
@@ -928,6 +935,7 @@ public class NumberSystem {
 	 * @throws Exception
 	 */
 	private Automaton multiplication(int n)throws Exception {
+		if(!is_neg && n < 0)throw new Exception("constant cannot be negative");
 		if(n == 0)throw new Exception("multiplication(0)");
 		if(multiplicationsDynamicTable.containsKey(n))return multiplicationsDynamicTable.get(n);
 		//note that the case of n==0 is handled in Computer class
@@ -970,6 +978,7 @@ public class NumberSystem {
 	 * @throws Exception
 	 */
 	private Automaton division(int n)throws Exception {
+		if(!is_neg && n < 0)throw new Exception("constant cannot be negative");
 		if(n == 0)throw new Exception("division by zero");
 		if(divisionsDynamicTable.containsKey(n))return divisionsDynamicTable.get(n);
 		Automaton R;

--- a/src/Automata/NumberSystem.java
+++ b/src/Automata/NumberSystem.java
@@ -84,7 +84,8 @@ public class NumberSystem {
 	 * -lessThan has two inputs, and it accepts iff the first
 	 * one is less than the second one. So the input is ordered!<br>
 	 * -equal has two inputs, and it accepts iff they are equal.
-	 * -comparison has two inputs, TODO.
+	 * -comparison_neg is defined only if the current number system is negative and has a corresponding comparable positive number system.
+	 * comparison_neg accepts inputs x,y if and only if x represents in the positive base the same non-negative integer and y does in the negative base.
 	 */
 	public Automaton addition;
 	public Automaton lessThan;

--- a/src/Automata/NumberSystem.java
+++ b/src/Automata/NumberSystem.java
@@ -508,7 +508,7 @@ public class NumberSystem {
 
 	/**
 	 * Initializes equality of base n and base -n. Equality has two inputs (a,b), and it accepts
-	 * iff [a]_n = [b]_-n (a is a base 2 representation and b is a base -2 representation of
+	 * iff [a]_n = [b]_-n (a is a base n representation and b is a base -n representation of
 	 * the same integer).
 	 * @param n
 	 * @throws Exception

--- a/src/Main/IntegrationTest.java
+++ b/src/Main/IntegrationTest.java
@@ -591,6 +591,20 @@ public class IntegrationTest {
 		L.add("eval test437 \"?lsd_neg_fib Ex,y y = 4*x+1 & y = 13\";");
 		L.add("eval test438 \"?lsd_neg_fib Ex 13 = 4*x+1\";");
 		L.add("eval test439 \"?lsd_neg_fib Ex 11 = 4*x+1\";");
+
+		// split, reverseSplit and join
+		L.add("split test440 T2[+][+];");
+		L.add("split test441 T2[+][-];");
+		L.add("split test442 T2[-][+];");
+		L.add("split test443 T2[-][-];");
+		L.add("rsplit test444[+][+] test440;");
+		L.add("rsplit test445[+][-] test441;");
+		L.add("rsplit test446[-][+] test442;");
+		L.add("rsplit test447[-][-] test443;");
+		L.add("join test448 test444[a][b] test445[a][b] test446[a][b] test447[a][b];");
+		L.add("split test449 T2[+][];");
+		L.add("rsplit test450[+][] T2;");
+		L.add("join test451 T[a] T2[a][b];");
 	}
 	public void runPerformanceTest(String name,int numberOfRuns) throws Exception{
 		PrintWriter out = new PrintWriter(new FileOutputStream(new File(directoryAddress+performanceTestFileName), true /* append = true */));

--- a/src/Main/Prover.java
+++ b/src/Main/Prover.java
@@ -40,7 +40,7 @@ import Automata.OstrowskiNumeration;
  * @author Hamoon
  */
 public class Prover {
-	static String REGEXP_FOR_THE_LIST_OF_COMMANDS = "(eval|def|macro|reg|load|ost|exit|quit|cls|clear|combine|morphism|promote|image|inf|split|rsplit|test)";
+	static String REGEXP_FOR_THE_LIST_OF_COMMANDS = "(eval|def|macro|reg|load|ost|exit|quit|cls|clear|combine|morphism|promote|image|inf|split|rsplit|join|test)";
 	static String REGEXP_FOR_EMPTY_COMMAND = "^\\s*(;|::|:)\\s*$";
 	/**
 	 * the high-level scheme of a command is a name followed by some arguments and ending in either ; : or ::
@@ -117,19 +117,26 @@ public class Prover {
 	static Pattern PATTERN_FOR_inf_COMMAND = Pattern.compile(REGEXP_FOR_inf_COMMAND);
 	static int GROUP_INF_NAME = 1;
 
-	static String REGEXP_FOR_split_COMMAND = "^\\s*split\\s+([a-zA-Z]\\w*)\\s+([a-zA-Z]\\w*)\\[(\\s*([+-]?\\s*,\\s*)*)([+-]?)\\s*]\\s*(;|::|:)\\s*$";
+	static String REGEXP_FOR_split_COMMAND = "^\\s*split\\s+([a-zA-Z]\\w*)\\s+([a-zA-Z]\\w*)((\\s*\\[\\s*[+-]?\\s*])+)\\s*(;|::|:)\\s*$";
 	static Pattern PATTERN_FOR_split_COMMAND = Pattern.compile(REGEXP_FOR_split_COMMAND);
-	static int GROUP_SPLIT_NAME = 1, GROUP_SPLIT_AUTOMATA = 2, GROUP_SPLIT_INPUT = 3, GROUP_SPLIT_FINAL_INPUT = 5, GROUP_SPLIT_END = 6;
-	static String REGEXP_FOR_INPUT_IN_split_COMMAND = "([+-]?)\\s*,\\s*";
+	static int GROUP_SPLIT_NAME = 1, GROUP_SPLIT_AUTOMATA = 2, GROUP_SPLIT_INPUT = 3, GROUP_SPLIT_END = 5;
+	static String REGEXP_FOR_INPUT_IN_split_COMMAND = "\\[\\s*([+-]?)\\s*]";
 	static Pattern PATTERN_FOR_INPUT_IN_split_COMMAND = Pattern.compile(REGEXP_FOR_INPUT_IN_split_COMMAND);
 
-	static String REGEXP_FOR_rsplit_COMMAND = "^\\s*rsplit\\s+([a-zA-Z]\\w*)\\[(\\s*([+-]?\\s*,\\s*)*)([+-]?)\\s*]\\s+([a-zA-Z]\\w*)\\s*(;|::|:)\\s*$";
+	static String REGEXP_FOR_rsplit_COMMAND = "^\\s*rsplit\\s+([a-zA-Z]\\w*)((\\s*\\[\\s*[+-]?\\s*])+)\\s+([a-zA-Z]\\w*)\\s*(;|::|:)\\s*$";
 	static Pattern PATTERN_FOR_rsplit_COMMAND = Pattern.compile(REGEXP_FOR_rsplit_COMMAND);
-	static int GROUP_RSPLIT_NAME = 1, GROUP_RSPLIT_AUTOMATA = 5, GROUP_RSPLIT_INPUT = 2, GROUP_RSPLIT_FINAL_INPUT = 4, GROUP_RSPLIT_END = 6;
-	static String REGEXP_FOR_INPUT_IN_rsplit_COMMAND = "([+-]?)\\s*,\\s*";
+	static int GROUP_RSPLIT_NAME = 1, GROUP_RSPLIT_AUTOMATA = 4, GROUP_RSPLIT_INPUT = 2, GROUP_RSPLIT_END = 5;
+	static String REGEXP_FOR_INPUT_IN_rsplit_COMMAND = "\\[\\s*([+-]?)\\s*]";
 	static Pattern PATTERN_FOR_INPUT_IN_rsplit_COMMAND = Pattern.compile(REGEXP_FOR_INPUT_IN_rsplit_COMMAND);
 
-	static String REGEXP_FOR_join_COMMAND = "^\\s*rsplit\\s+([a-zA-Z]\\w*)\\[(\\s*([+-]?\\s*,\\s*)*)([+-]?)\\s*]\\s+([a-zA-Z]\\w*)\\s*(;|::|:)\\s*$";
+	static String REGEXP_FOR_join_COMMAND = "^\\s*join\\s+([a-zA-Z]\\w*)((\\s+([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z]\\s*])+))*)\\s*(;|::|:)\\s*";
+	static Pattern PATTERN_FOR_join_COMMAND = Pattern.compile(REGEXP_FOR_join_COMMAND);
+	static int GROUP_JOIN_NAME = 1, GROUP_JOIN_AUTOMATA = 2, GROUP_JOIN_END = 7;
+	static String REGEXP_FOR_AN_AUTOMATON_IN_join_COMMAND = "([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z]\\s*])+)";
+	static Pattern PATTERN_FOR_AN_AUTOMATON_IN_join_COMMAND = Pattern.compile(REGEXP_FOR_AN_AUTOMATON_IN_join_COMMAND);
+	static int GROUP_JOIN_AUTOMATON_NAME = 1, GROUP_JOIN_AUTOMATON_INPUT = 2;
+	static String REGEXP_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND = "\\[\\s*([a-zA-Z])\\s*]";
+	static Pattern PATTERN_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND = Pattern.compile(REGEXP_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND);
 
 	static String REGEXP_FOR_test_COMMAND = "^\\s*test\\s+([a-zA-Z]\\w*)\\s*(\\d+)\\s*(;|::|:)\\s*$";
 	static Pattern PATTERN_FOR_test_COMMAND = Pattern.compile(REGEXP_FOR_test_COMMAND);
@@ -301,6 +308,8 @@ public class Prover {
 			splitCommand(s);
 		} else if (commandName.equals("rsplit")) {
 			rsplitCommand(s);
+		} else if (commandName.equals("join")) {
+			joinCommand(s);
 		} else if (commandName.equals("test")) {
 			testCommand(s);
 		} else {
@@ -339,6 +348,12 @@ public class Prover {
 			return promoteCommand(s);
 		} else if(commandName.equals("image")) {
 			return imageCommand(s);
+		} else if (commandName.equals("split")) {
+			return splitCommand(s);
+		} else if (commandName.equals("rsplit")) {
+			return rsplitCommand(s);
+		} else if (commandName.equals("join")) {
+			return joinCommand(s);
 		} else {
 			throw new Exception("Invalid command: " + commandName);
 		}
@@ -671,7 +686,7 @@ public class Prover {
 		}
 	}
 
-	public static boolean splitCommand(String s) throws Exception {
+	public static TestCase splitCommand(String s) throws Exception {
 		Matcher m = PATTERN_FOR_split_COMMAND.matcher(s);
 		if(!m.find()) {
 			throw new Exception("Invalid use of split command.");
@@ -684,20 +699,19 @@ public class Prover {
 		StringBuffer log = new StringBuffer();
 
 		Matcher m1 = PATTERN_FOR_INPUT_IN_split_COMMAND.matcher(m.group(GROUP_SPLIT_INPUT));
-		List<String> inputs = new ArrayList<String>();
-		boolean doesSplit = false;
+		List<String> inputs = new ArrayList<>();
+		boolean hasInput = false;
 		while(m1.find()) {
 			String t = m1.group(1);
-			doesSplit = doesSplit || t.equals("+") || t.equals("-");
+			hasInput = hasInput || t.equals("+") || t.equals("-");
 			inputs.add(t);
 		}
-		if((!doesSplit || inputs.size() == 0) && m.group(GROUP_SPLIT_FINAL_INPUT).equals("")) {
+		if(!hasInput || inputs.size() == 0) {
 			throw new Exception("Cannot split without inputs.");
 		}
-		inputs.add(m.group(GROUP_SPLIT_FINAL_INPUT));
 		List<Integer> outputs = new ArrayList<>(M.O);
 		UtilityMethods.removeDuplicates(outputs);
-		List<Automaton> subautomata = M.clone().uncombine(outputs,printSteps,prefix,log);
+		List<Automaton> subautomata = M.uncombine(outputs,printSteps,prefix,log);
 		for (int i = 0; i < subautomata.size(); i++) {
 			Automaton N = subautomata.get(i).split(inputs,printSteps,prefix,log);
 			subautomata.set(i, N);
@@ -708,10 +722,10 @@ public class Prover {
 		N.draw(UtilityMethods.get_address_for_result()+m.group(GROUP_SPLIT_NAME)+".gv", s, true);
 		N.write(UtilityMethods.get_address_for_result()+m.group(GROUP_SPLIT_NAME)+".txt");
 		N.write(UtilityMethods.get_address_for_words_library()+m.group(GROUP_SPLIT_NAME)+".txt");
-		return true;
+		return new TestCase(s, N, "", "", "");
 	}
 
-	public static boolean rsplitCommand(String s) throws Exception {
+	public static TestCase rsplitCommand(String s) throws Exception {
 		Matcher m = PATTERN_FOR_rsplit_COMMAND.matcher(s);
 		if(!m.find()) {
 			throw new Exception("Invalid use of reverse split command.");
@@ -724,20 +738,19 @@ public class Prover {
 		StringBuffer log = new StringBuffer();
 
 		Matcher m1 = PATTERN_FOR_INPUT_IN_rsplit_COMMAND.matcher(m.group(GROUP_RSPLIT_INPUT));
-		List<String> inputs = new ArrayList<String>();
-		boolean doesSplit = false;
+		List<String> inputs = new ArrayList<>();
+		boolean hasInput = false;
 		while(m1.find()) {
 			String t = m1.group(1);
-			doesSplit = doesSplit || t.equals("+") || t.equals("-");
+			hasInput = hasInput || t.equals("+") || t.equals("-");
 			inputs.add(t);
 		}
-		if((!doesSplit || inputs.size() == 0) && m.group(GROUP_RSPLIT_FINAL_INPUT).equals("")) {
-			throw new Exception("Cannot reverse split without inputs.");
+		if(!hasInput || inputs.size() == 0) {
+			throw new Exception("Cannot split without inputs.");
 		}
-		inputs.add(m.group(GROUP_RSPLIT_FINAL_INPUT));
 		List<Integer> outputs = new ArrayList<>(M.O);
 		UtilityMethods.removeDuplicates(outputs);
-		List<Automaton> subautomata = M.clone().uncombine(outputs,printSteps,prefix,log);
+		List<Automaton> subautomata = M.uncombine(outputs,printSteps,prefix,log);
 		for (int i = 0; i < subautomata.size(); i++) {
 			Automaton N = subautomata.get(i).reverseSplit(inputs,printSteps,prefix,log);
 			subautomata.set(i, N);
@@ -748,7 +761,44 @@ public class Prover {
 		N.draw(UtilityMethods.get_address_for_result()+m.group(GROUP_RSPLIT_NAME)+".gv", s, true);
 		N.write(UtilityMethods.get_address_for_result()+m.group(GROUP_RSPLIT_NAME)+".txt");
 		N.write(UtilityMethods.get_address_for_words_library()+m.group(GROUP_RSPLIT_NAME)+".txt");
-		return true;
+		return new TestCase(s, N, "", "", "");
+	}
+
+	public static TestCase joinCommand(String s) throws Exception {
+		Matcher m = PATTERN_FOR_join_COMMAND.matcher(s);
+		if(!m.find()) {
+			throw new Exception("Invalid use of reverse split command.");
+		}
+		boolean printSteps = m.group(GROUP_JOIN_END).equals(":");
+		boolean printDetails = m.group(GROUP_JOIN_END).equals("::");
+		String prefix = new String();
+		StringBuffer log = new StringBuffer();
+
+		Matcher m1 = PATTERN_FOR_AN_AUTOMATON_IN_join_COMMAND.matcher(m.group(GROUP_JOIN_AUTOMATA));
+		List<Automaton> subautomata = new ArrayList<>();
+		while (m1.find()) {
+			String automatonName = m1.group(GROUP_JOIN_AUTOMATON_NAME);
+			Automaton M = new Automaton(UtilityMethods.get_address_for_words_library()+automatonName+".txt");
+			String automatonInputs = m1.group(GROUP_JOIN_AUTOMATON_INPUT);
+			Matcher m2 = PATTERN_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND.matcher(automatonInputs);
+			List<String> label = new ArrayList<>();
+			while (m2.find()) {
+				String t = m2.group(1);
+				label.add(t);
+			}
+			if (label.size() != M.A.size()) {
+				throw new Exception("Number of inputs of word automata " + automatonName + " does not match number of inputs specified.");
+			}
+			M.label = label;
+			subautomata.add(M);
+		}
+		Automaton N = subautomata.remove(0);
+		N = N.join(new LinkedList<>(subautomata),printSteps, prefix,log);
+
+		N.draw(UtilityMethods.get_address_for_result()+m.group(GROUP_JOIN_NAME)+".gv", s, true);
+		N.write(UtilityMethods.get_address_for_result()+m.group(GROUP_JOIN_NAME)+".txt");
+		N.write(UtilityMethods.get_address_for_words_library()+m.group(GROUP_JOIN_NAME)+".txt");
+		return new TestCase(s, N, "", "", "");
 	}
 
 	public static void testCommand(String s) throws Exception {

--- a/src/Main/Prover.java
+++ b/src/Main/Prover.java
@@ -24,8 +24,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.LinkedList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -129,13 +132,13 @@ public class Prover {
 	static String REGEXP_FOR_INPUT_IN_rsplit_COMMAND = "\\[\\s*([+-]?)\\s*]";
 	static Pattern PATTERN_FOR_INPUT_IN_rsplit_COMMAND = Pattern.compile(REGEXP_FOR_INPUT_IN_rsplit_COMMAND);
 
-	static String REGEXP_FOR_join_COMMAND = "^\\s*join\\s+([a-zA-Z]\\w*)((\\s+([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z]\\s*])+))*)\\s*(;|::|:)\\s*";
+	static String REGEXP_FOR_join_COMMAND = "^\\s*join\\s+([a-zA-Z]\\w*)((\\s+([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z&&[^AE]]\\w*\\s*])+))*)\\s*(;|::|:)\\s*";
 	static Pattern PATTERN_FOR_join_COMMAND = Pattern.compile(REGEXP_FOR_join_COMMAND);
 	static int GROUP_JOIN_NAME = 1, GROUP_JOIN_AUTOMATA = 2, GROUP_JOIN_END = 7;
-	static String REGEXP_FOR_AN_AUTOMATON_IN_join_COMMAND = "([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z]\\s*])+)";
+	static String REGEXP_FOR_AN_AUTOMATON_IN_join_COMMAND = "([a-zA-Z]\\w*)((\\s*\\[\\s*[a-zA-Z&&[^AE]]\\w*\\s*])+)";
 	static Pattern PATTERN_FOR_AN_AUTOMATON_IN_join_COMMAND = Pattern.compile(REGEXP_FOR_AN_AUTOMATON_IN_join_COMMAND);
 	static int GROUP_JOIN_AUTOMATON_NAME = 1, GROUP_JOIN_AUTOMATON_INPUT = 2;
-	static String REGEXP_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND = "\\[\\s*([a-zA-Z])\\s*]";
+	static String REGEXP_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND = "\\[\\s*([a-zA-Z&&[^AE]]\\w*)\\s*]";
 	static Pattern PATTERN_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND = Pattern.compile(REGEXP_FOR_AN_AUTOMATON_INPUT_IN_join_COMMAND);
 
 	static String REGEXP_FOR_test_COMMAND = "^\\s*test\\s+([a-zA-Z]\\w*)\\s*(\\d+)\\s*(;|::|:)\\s*$";


### PR DESCRIPTION
Added split,rsplit and join commands. For sake of example, consider T2, the Word Automata which takes two inputs in `msd_neg_2`, and the following commands:
```
split M1 T2[+][+];
split M2 T2[+][-];
split M3 T2[-][+];
split M4 T2[-][-];
rsplit N1[+][+] M1;
rsplit N2[+][-] M2;
rsplit N3[-][+] M3;
rsplit N4[-][-] M4;
join T2_new N1[a][b] N2[a][b] N3[a][b] N4[a][b];
```
1. The first 4 commands creates the Word Automata M1, M2, M3, M4 which on inputs x,y in `msd_2`, outputs T2[x'][y'], T2[x'][-y'], T2[-x'][y'] and T2[-x'][-y'] repsectively where x',-x',y',-y' are the `msd_neg_2` representations of x,-x,y,-y.
2. The next 4 commands creates the Word Automata N1, N2, N3, N4 which on inputs x',y' in `msd_neg_2`, outputs M1[x][y], M2[x][-y], M3[-x][y], M4[-x][-y] respectively where x,-x,y,-y are the `msd_2` representations of x,-x,y,-y. If no msd_2 representation exists, then the output is zero.
3. The final command gives the automata which given inputs a,b, outputs the first non-zero value value of N1[a][b] N2[a][b] N3[a][b] N4[a][b]. Hence, T2_new should be the same automata as T2.

### Negative and positive base comparison
Added comparison between base k and base -k. This is the automata C_k with two inputs a,b in `msd_k`, `msd_neg_k` which accepts if and only if a and b represent the same number. This is stored as a field on the NumberSystem for base -k always. In the future, if any more comparisons are added, they can be stored in the same way.

### Split command
Given the command `split M N[+][-][]`, we expect N to be a Word Automata with first two inputs in some negative base (which can be compared to some positive base). Then, the command will create the Word Automata M which on inputs x,y,z outputs N[x'][y'][z] where x = x' and y = -y' (compared using the corresponding comparison automata). In particular, we expect the symbol inside of [ ] to be "+", "-", or "".

The way this is done is to first uncombine the automaton N (one for each output). For each uncombined automaton N', create the automaton accepting `Ex' Ex' N'[x'][y'][z] = @1 & x = x' & y = -y'`. Then, recombine all these new automaton. (The reason for the uncombining and combining is because the automata operations cross product and minimize do not work automatically for automata with output).

### Reverse Split command
Given the command `rsplit M[+][-][] N`, we expect N to be a Word Automata with first two inputs in some positive base (which can be compared to some negative base). Then, the command will create the Word Automata M which on inputs x',y',z' outputs N[x][y][z'] where x = x' and y = -y' (compared using the corresponding comparison automata). If no x or y exists (x' < 0 or y' > 0) then the automaton M should output 0. In particular, we expect the symbol inside of [ ] to be "+", "-", or "".

The implementation of reverse split is nearly identical the that of the split command.

### Join command
Gven the command `join M N1[a][b] N2[b][c]`, we expect N1 and N2 to be Word Automata both with two inputs. Then, the command will create the Word Automata M which on inputs x,y,z outputs the first non-zero value of N1[a][b], N2[b][c].

The way this is done is to first label N1 with a,b, N2 with b,c. Then, take the cross product of N1 and N2 and set the output to be the first non-zero output. Finally we minimize.

### Misc Changes
1. Re-added checks for negative constants in positive bases.
2. Added a uncombine function on automata, which seperates an automata with n outputs into n automta without outputs.
3. Added a minimize for automata with output. This is done by uncombining, minimizing and recombining. This works since a combining minimal automata creates a new minimal automata.
4. Added logging for combine.