### PR TITLE
Added inf quantifier

### DIFF
--- a/src/Main/IntegrationTest.java
+++ b/src/Main/IntegrationTest.java
@@ -683,6 +683,11 @@ public class IntegrationTest {
 		L.add("eval test517 \"?msd_neg_2 TH[a<5] / TEST[b-d] = 2\";");
 		L.add("eval test518 \"TH[a<5] = TH[b-d]\";");
 		L.add("eval test519 \"T[a<5] <= T[b-d]\";");
+
+		// inf quantifier tests
+		L.add("eval test520 \"?lsd_10 Ix x > 0\";");
+		L.add("eval test521 \"?msd_10 Ix x + y = z & z <= 5\";");
+		L.add("eval test522 \"?msd_neg_10 Ix 2*x = y & y >5\";");
 	}
 	public void runPerformanceTest(String name,int numberOfRuns) throws Exception{
 		PrintWriter out = new PrintWriter(new FileOutputStream(new File(directoryAddress+performanceTestFileName), true /* append = true */));

--- a/src/Main/Predicate.java
+++ b/src/Main/Predicate.java
@@ -69,15 +69,15 @@ public class Predicate {
 		return number_system_Hash;
 	}
 
-	static String REGEXP_FOR_LOGICAL_OPERATORS = "\\G\\s*(`|\\^|\\&|\\~|\\||=>|<=>|E|A)";
-	static String REGEXP_FOR_LIST_OF_QUANTIFIED_VARIABLES = "\\G\\s*((\\s*([a-zA-Z&&[^AE]]\\w*)\\s*)(\\s*,\\s*([a-zA-Z&&[^AE]]\\w*)\\s*)*)";
+	static String REGEXP_FOR_LOGICAL_OPERATORS = "\\G\\s*(`|\\^|\\&|\\~|\\||=>|<=>|E|A|I)";
+	static String REGEXP_FOR_LIST_OF_QUANTIFIED_VARIABLES = "\\G\\s*((\\s*([a-zA-Z&&[^AEI]]\\w*)\\s*)(\\s*,\\s*([a-zA-Z&&[^AEI]]\\w*)\\s*)*)";
 	static String REGEXP_FOR_RELATIONAL_OPERATORS = "\\G\\s*(>=|<=|<|>|=|!=)";
 	static String REGEXP_FOR_ARITHMETIC_OPERATORS = "\\G\\s*(_|/|\\*|\\+|\\-)";
 	static String REGEXP_FOR_NUMBER_SYSTEM = "\\G\\s*\\?(((msd|lsd)_(\\d+|\\w+))|((msd|lsd)(\\d+|\\w+))|(msd|lsd)|(\\d+|\\w+))";
-	static String REGEXP_FOR_WORD = "\\G\\s*([a-zA-Z&&[^AE]]\\w*)\\s*\\[";
-	static String REGEXP_FOR_FUNCTION = "\\G\\s*\\$([a-zA-Z&&[^AE]]\\w*)\\s*\\(";
-	static String REGEXP_FOR_MACRO = "\\G(\\s*)\\#([a-zA-Z&&[^AE]]\\w*)\\s*\\(";
-	static String REGEXP_FOR_VARIABLE = "\\G\\s*([a-zA-Z&&[^AE]]\\w*)";
+	static String REGEXP_FOR_WORD = "\\G\\s*([a-zA-Z&&[^AEI]]\\w*)\\s*\\[";
+	static String REGEXP_FOR_FUNCTION = "\\G\\s*\\$([a-zA-Z&&[^AEI]]\\w*)\\s*\\(";
+	static String REGEXP_FOR_MACRO = "\\G(\\s*)\\#([a-zA-Z&&[^AEI]]\\w*)\\s*\\(";
+	static String REGEXP_FOR_VARIABLE = "\\G\\s*([a-zA-Z&&[^AEI]]\\w*)";
 	static String REGEXP_FOR_NUMBER_LITERAL = "\\G\\s*(\\d+)";
 	static String REGEXP_FOR_ALPHABET_LETTER = "\\G\\s*@(\\s*(\\+|\\-)?\\s*\\d+)";
 	static String REGEXP_FOR_LEFT_PARENTHESIS = "\\G\\s*\\(";
@@ -147,7 +147,7 @@ public class Predicate {
 			if(MATCHER_FOR_LOGICAL_OPERATORS.find(index)){
 				lastTokenWasOperator = true;
 				Matcher matcher = MATCHER_FOR_LOGICAL_OPERATORS;
-				if(matcher.group(1).equals("E") || matcher.group(1).equals("A")){
+				if(matcher.group(1).equals("E") || matcher.group(1).equals("A") || matcher.group(1).equals("I")){
 					if(!MATCHER_FOR_LIST_OF_QUANTIFIED_VARIABLES.find(matcher.end())){
 						throw new Exception(
 							"Operator " + matcher.group(1) +

--- a/src/Main/Prover.java
+++ b/src/Main/Prover.java
@@ -909,35 +909,7 @@ public class Prover {
 		// When dealing with enumerating values (eg. inf and test commands), we remove leading zeroes in the case of msd
 		// and trailing zeroes in the case of lsd. To do this, we construct a reg subcommand that generates the complement
 		// of zero-prefixed strings for msd and zero suffixed strings for lsd, then intersect this with our original automaton.
-		String removeZeroesReg = "";
-		String zero = "";
-		if (M.A.size() == 1) {
-			zero = "0";
-		}
-		else {
-			zero = "[" + String.join(",", Collections.nCopies(M.A.size(), "0")) + "]";
-		}
-
-		removeZeroesReg += "reg " + name + "_rem0 ";
-		for (int i=0; i<M.A.size(); i++) {
-			String alphaString = M.A.get(i).toString();
-			alphaString = alphaString.substring(1, alphaString.length()-1);
-			alphaString = "{" + alphaString + "} ";
-			removeZeroesReg += alphaString;
-		}
-
-		if (M.NS.get(0).isMsd()) {
-			removeZeroesReg += "\"~(" + zero + ".*)\";";
-		}
-		else {
-			removeZeroesReg += "\"~(.*" + zero + ")\";";
-		}
-		TestCase retrieval = regCommand(removeZeroesReg);
-		Automaton R = retrieval.result.clone();
-		// and-ing automata uses the cross product routine, which requires labeled automata
 		M.randomLabel();
-		R.label = M.label;
-		M = M.and(R, false, null, null);
-		return M;
+		return M.removeLeadingZeroes(M.label, false, null, null);
 	}
 }

--- a/src/Token/LogicalOperator.java
+++ b/src/Token/LogicalOperator.java
@@ -49,7 +49,7 @@ public class LogicalOperator extends Operator{
 		if(S.size() < getArity())throw new Exception("operator " + op + " requires " + getArity()+ " operands");
 		
 		if(op.equals("~") || op.equals("`")){actNegationOrReverse(S,print,prefix,log);return;}
-		if(op.equals("E") || op.equals("A")){actQuantifier(S,print,prefix,log);return;}
+		if(op.equals("E") || op.equals("A") || op.equals("I")){actQuantifier(S,print,prefix,log);return;}
 		
 		Expression b = S.pop();
 		Expression a = S.pop();
@@ -132,11 +132,14 @@ public class LogicalOperator extends Operator{
 				M = operands.get(i).M;
 				if(op.equals("E")){
 					M.quantify(new HashSet<String>(list_of_identifiers_to_quantify),print,prefix+" ",log);
-				}
-				else{
+				} else if (op.equals("A")){
 					M.not(print,prefix+" ",log);
 					M.quantify(new HashSet<String>(list_of_identifiers_to_quantify),print,prefix+" ",log);
 					M.not(print,prefix+" ",log);
+				} else {
+					M = M.removeLeadingZeroes(list_of_identifiers_to_quantify, print, prefix+" ", log);
+					String infReg = M.infinite();
+					M = infReg.equals("") ? new Automaton(false) : new Automaton(true);
 				}
 			}
 		}

--- a/src/Token/Operator.java
+++ b/src/Token/Operator.java
@@ -29,7 +29,7 @@ public abstract class Operator extends Token{
 		return true;
 	}
 	public void put(List<Token> postOrder,Stack<Operator> S)throws Exception{
-		if(op.equals("(") || op.equals("E") || op.equals("A")){
+		if(op.equals("(") || op.equals("E") || op.equals("A") || op.equals("I")){
 			S.push(this);
 			return;
 		}
@@ -78,6 +78,7 @@ public abstract class Operator extends Token{
 			case "<=>":priority = 110;break;
 			case "E":priority = 150;break;
 			case "A":priority = 150;break;
+			case "I":priority = 150;break;
 			case "(":priority = 200;break;
 			default:
 				priority = Integer.MAX_VALUE;


### PR DESCRIPTION
Added inf quantifer "I". Can now write expressions like "?msd_2 Ix,y x + y >= 2" to denote: Does there exists infinitely many pairs (x,y) such that x + y >= 2. This is done in removeLeadingZeroes by first forcing the automaton to have non-zero leading digit (on inputs in msd), and non-zero trailing digit (on input in lsd), then checking if the automaton has a cycle.

Other Changes:
- When finding cycles, we no longer require first minimizing the automaton. I'm not sure why this was done and I don't think it's needed. We may want to revert this change.
- Previously, we removed leading/trialing zeroes using a regular expression in the prover. This is now replaced with removeLeadingZeroes in the Automaton, which explicitly constructs the automaton instead of using a regular expresion.