### PR TITLE
Added result folder

### DIFF
--- a/Result/.gitkeep
+++ b/Result/.gitkeep
@@ -1,0 +1,1 @@
+Empty file, so the Result folder is committed.


### PR DESCRIPTION
We have a placeholder empty file .gitkeep, so the result folder is committed. (You cannot commit empty folders in git.)